### PR TITLE
`librna-sys v0.3.0-pre.*`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,8 @@ cff-version: 1.2.0
 title: librna-sys
 message: >-
   If you use this software, please cite it using the
-  metadata from this file.
+  metadata from its CITATION.cff file. If applicable,
+  choose a version-release-specific DOI from Zenodo.
 type: software
 authors:
   - given-names: Vincent
@@ -25,8 +26,8 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.12543036
     description: The unversioned DOI of this work.
-version: 0.2.3
-date-released: '2024-06-26'
+version: 0.3.0-pre.0
+date-released: '2024-09-DD'
 references:
   - type: article
     authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,7 +26,7 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.12543036
     description: The unversioned DOI of this work.
-version: 0.3.0-pre.0
+version: 0.3.0-pre.1
 date-released: '2024-09-DD'
 references:
   - type: article

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,9 +25,6 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.12543036
     description: The unversioned DOI of this work.
-  - type: doi
-    value: 10.5281/zenodo.12543037
-    description: The DOI for v0.2.3 of this work.
 version: 0.2.3
 date-released: '2024-06-26'
 references:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.12543036
     description: The unversioned DOI of this work.
-version: 0.3.0-pre.1
-date-released: '2024-09-DD'
+version: 0.3.0-pre.2
+date-released: '2024-09-12'
 references:
   - type: article
     authors:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 description = "Low-level bindings for the ViennaRNA library."
 keywords = ["viennarna", "rna", "bioinformatics", "sys", "ffi"]
 categories = ["external-ffi-bindings", "science"]
-version = "0.3.0-pre.0"
+version = "0.3.0-pre.1"
 edition = "2018"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 description = "Low-level bindings for the ViennaRNA library."
 keywords = ["viennarna", "rna", "bioinformatics", "sys", "ffi"]
 categories = ["external-ffi-bindings", "science"]
-version = "0.2.3"
+version = "0.3.0-pre.0"
 edition = "2018"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 crate-type = ["lib"]
 
 [build-dependencies]
-bindgen = "~0.64"
+bindgen = "~0.70"
 pkg-config = { version = "~0.3", optional = true }
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ bindgen = "~0.64"
 pkg-config = { version = "~0.3", optional = true }
 
 [dependencies]
-openmp-sys = { version = "1.2.3", optional = true }
 
 [dev-dependencies]
 libc = "~0.2"
@@ -32,9 +31,6 @@ pyo3 = { version = "~0.16", features = ["extension-module"] }
 [features]
 default = []
 auto = ["pkg-config"]
-openmp = ["openmp-sys"]
-static-openmp = ["openmp-sys?/static"]
-
 
 [[example]]
 name = "bpdist"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ pkg-config = { version = "~0.3", optional = true }
 
 [dev-dependencies]
 libc = "~0.2"
-pyo3 = { version = "~0.16", features = ["extension-module"] }
+pyo3 = { version = "~0.22", features = ["extension-module"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,10 @@ crate-type = ["lib"]
 
 [build-dependencies]
 bindgen = "~0.64"
-pkg-config = { optional = true, version = "~0.3" }
+pkg-config = { version = "~0.3", optional = true }
 
 [dependencies]
+openmp-sys = { version = "1.2.3", optional = true }
 
 [dev-dependencies]
 libc = "~0.2"
@@ -31,6 +32,8 @@ pyo3 = { version = "~0.16", features = ["extension-module"] }
 [features]
 default = []
 auto = ["pkg-config"]
+openmp = ["openmp-sys"]
+static-openmp = ["openmp-sys?/static"]
 
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 description = "Low-level bindings for the ViennaRNA library."
 keywords = ["viennarna", "rna", "bioinformatics", "sys", "ffi"]
 categories = ["external-ffi-bindings", "science"]
-version = "0.3.0-pre.1"
+version = "0.3.0-pre.2"
 edition = "2018"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This crate provides low-level Rust bindings to [`libRNA/RNAlib/ViennaRNA`](https
 
 `librna-sys` is mostly **experimental** and provides **unsafe low-level bindings**.
 You might encounter issues with building or linking this crate but common installation setups of ViennaRNA should work reliably.
-This crate was only tested on Linux but macOS should work as well.
+This crate was only tested on Linux. MacOS might work, possibly with some adjustments.
 
 ### Compatibility
 
@@ -56,7 +56,7 @@ export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBRNA_PREFIX/lib/pkgconfig"
 
 ### Using Environment Variables
 
-`librna-sys` exposes two environment variables in case `pkg-config` is not available.
+`librna-sys` exposes two environment variables in case `pkg-config` is not available or the `auto` feature is not enabled.
 Use them like this:
 
 ```sh
@@ -96,7 +96,7 @@ cargo build --release --example bpdist #--features auto
 ```
 
 produces a dynamic library `target/release/examples/libbpdist.so` exposing `Python` bindings.
-Copy it whereever you want and import it like this:
+Copy it wherever you want and import it like this:
 
 ```python
 from libbpdist import bp_distance_pk
@@ -110,7 +110,7 @@ I'm open to any ideas or advice.
 
 It is not necessarily planned to provide *complete, safe* bindings to ViennaRNA.
 However, I would like to restructure this project slightly and add a crate `librna-rs`
-That provides a safely wrapped subset of ViennaRNA functionality that can be extended when the need arises.
+providing a safely wrapped subset of ViennaRNA functionality that can be extended when the need arises.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ This crate was only tested on Linux. MacOS might work, possibly with some adjust
 | `0.2.0` | `2.6.0 - 2.6.2` | Added new header files introduced since 2.4.18 through 2.6.0 |
 | `0.2.1` | `>=2.6.3` | Removed workaround for issue fixed in [#189](https://github.com/ViennaRNA/ViennaRNA/pull/189). |
 | `>=0.2.2` | `>=2.6.4` | Re-added `vrna_config.h` which was removed in `0.2.1` as a workaround for an issue fixed in [#199](https://github.com/ViennaRNA/ViennaRNA/pull/199) |
-| `>=0.3.0` | `>=2.7.0` | Issue [#3](https://github.com/fncnt/librna-sys/issues/3) should be resolved. Added new header files for `2.7.0` |
+| `>=0.3.0` | **`>=2.5.0`** | Issue [#3](https://github.com/fncnt/librna-sys/issues/3) should be resolved. Added new header files for `2.7.0` |
 
 This chart might be inconsinstent and incomplete. Please report any inaccuracies.
+Since `librna-sys@0.2.0`, new minor versions have been released in lockstep with new minor versions of ViennaRNA.
 In general, only the latest version of ViennaRNA is supported but please reach out if you try to make an older version work.
-Since `librna-sys@0.2.0`, new minor versions have been released in lockstep with new backwards-incompatible versions of ViennaRNA.
+
+**`librna-sys>=0.3.0` restores backwards-compatibility with ViennaRNA `>=2.5.0`** (cf. below for known issues).
 
 ## Prerequisites
 
@@ -124,4 +126,3 @@ ViennaRNA is linked against OpenMP both internally and in its bundled `libsvm` d
 **Prior to version `2.7.0`**, this could cause linking issues with the Rust compiler.
 
 This can be solved by adding [`openmp-sys`](https://crates.io/crates/openmp-sys) in downstream Rust code.
-However, this shouldn't be necessary with `librna-sys>=0.3` and ViennaRNA `>=2.7.0`.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ librna-sys = { version = "0.2" , features = ["auto"] }
 
 may be used instead of setting environment variables.
 
+## Linking OpenMP
+
+ViennaRNA is linked against OpenMP both internally and in its bundled `libsvm` dependency.
+The latter may cause linking issues with the Rust compiler.
+
+This can be solved by adding [`openmp-sys`](https://crates.io/crates/openmp-sys) in downstream Rust code.
+
+For convenience, `librna-sys` exposes two cargo features that directly follow `openmp-sys`; `openmp` and `static-openmp`.
+The latter has to be enabled in conjunction with the former to show any effect.
+
+However, using `openmp-sys` directly is arguably cleaner and more flexible as downstream crates would not need to pass through
+cargo features to provide the same level of control.
+
 ## Usage
 
 Please refer to the [original documentation](https://www.tbi.univie.ac.at/RNA/ViennaRNA/doc/html/index.html) of the `C` API.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This crate was only tested on Linux but macOS should work as well.
 
 This chart might be inconsinstent and incomplete. Please report any inaccuracies.
 In general, only the latest version of ViennaRNA is supported but please reach out if you try to make an older version work.
-Starting with `librna-sys@0.2.0`, new minor versions have been released in lockstep with new backwards-incompatible versions of ViennaRNA.
+Since `librna-sys@0.2.0`, new minor versions have been released in lockstep with new backwards-incompatible versions of ViennaRNA.
 
 ## Prerequisites
 
@@ -45,16 +45,28 @@ librna-sys = { version = "0.3" , features = ["auto"] }
 ```
 
 may be used to automatically set the correct linking options.
+If ViennaRNA is installed into a custom prefix that `pkg-config` is *not* aware of,
+you can use environment variables to tell `pkg-config` where to look:
+
+```sh
+export LIBRNA_PREFIX=/not/usr # for convenience
+
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBRNA_PREFIX/lib/pkgconfig"
+```
 
 ### Using Environment Variables
 
-`librna-sys` exposes two environment variables in case ViennaRNA is installed in a custom directory.
+`librna-sys` exposes two environment variables in case `pkg-config` is not available.
 Use them like this:
 
 ```sh
-export LIBRNA_INCLUDE_DIR=/path/to/headerdirectory # default: /usr/include
-export LIBRNA_LIB_DIR=/path/to/librarydirectory # default: /usr/lib
+export LIBRNA_INCLUDE_DIR=$LIBRNA_PREFIX/include # default: /usr/include
+export LIBRNA_LIB_DIR=$LIBRNA_PREFIX/lib # default: /usr/lib
 ```
+
+However, note that this approach is limited and assumes a certain set of linker arguments.
+This might cause problems if your ViennaRNA configuration is unusual.
+If possible, prefer using `pkg-config`.
 
 Afterwards the crate can be used as a dependency in `Cargo.toml`:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This crate was only tested on Linux but macOS should work as well.
 | `0.2.0` | `2.6.0 - 2.6.2` | Added new header files introduced since 2.4.18 through 2.6.0 |
 | `0.2.1` | `>=2.6.3` | Removed workaround for issue fixed in [#189](https://github.com/ViennaRNA/ViennaRNA/pull/189). |
 | `>=0.2.2` | `>=2.6.4` | Re-added `vrna_config.h` which was removed in `0.2.1` as a workaround for an issue fixed in [#199](https://github.com/ViennaRNA/ViennaRNA/pull/199) |
+| `>=0.3.0` | `>=2.7.0` | Issue [#3](https://github.com/fncnt/librna-sys/issues/3) should be resolved now. Added new header files for `2.7.0` |
 
 This chart might be inconsinstent and incomplete. Please report any inaccuracies.
 In general, only the latest version of ViennaRNA is supported but please reach out if you try to make an older version work.
@@ -33,6 +34,17 @@ Starting with `librna-sys@0.2.0`, I aim to release new minor versions in lockste
 This crate requires the static library (`libRNA.a` on Linux and macOS) as well as the `C` header files.
 
 ## Configuration
+
+### Using `pkg-config` (preferred method)
+
+If `pkg-config` is available on your system and `ViennaRNA` was installed properly
+
+```toml
+[dependencies]
+librna-sys = { version = "0.3" , features = ["auto"] }
+```
+
+may be used to automatically set the correct linking options.
 
 ### Using Environment Variables
 
@@ -48,32 +60,8 @@ Afterwards the crate can be used as a dependency in `Cargo.toml`:
 
 ```toml
 [dependencies]
-librna-sys = "0.2"
+librna-sys = "0.3"
 ```
-
-### Using `pkg-config`
-
-If `pkg-config` is available on your system and `ViennaRNA` was installed properly
-
-```toml
-[dependencies]
-librna-sys = { version = "0.2" , features = ["auto"] }
-```
-
-may be used instead of setting environment variables.
-
-## Linking OpenMP
-
-ViennaRNA is linked against OpenMP both internally and in its bundled `libsvm` dependency.
-The latter may cause linking issues with the Rust compiler.
-
-This can be solved by adding [`openmp-sys`](https://crates.io/crates/openmp-sys) in downstream Rust code.
-
-For convenience, `librna-sys` exposes two cargo features that directly follow `openmp-sys`; `openmp` and `static-openmp`.
-The latter has to be enabled in conjunction with the former to show any effect.
-
-However, using `openmp-sys` directly is arguably cleaner and more flexible as downstream crates would not need to pass through
-cargo features to provide the same level of control.
 
 ## Usage
 
@@ -117,3 +105,11 @@ At this point, it's not yet clear where this is going but here are a few thought
 If you encounter an error including `generated with LTO version X.0 instead of the expected Y.0`,
 you could either recompile `ViennaRNA` yourself or [downgrade your `Rust` toolchain](https://doc.rust-lang.org/rustc/linker-plugin-lto.html#toolchain-compatibility).
 Adjusting some [linker-related codegen options](https://doc.rust-lang.org/rustc/codegen-options/index.html#linker) might also help but was not thoroughly tested.
+
+### Linking OpenMP
+
+ViennaRNA is linked against OpenMP both internally and in its bundled `libsvm` dependency.
+**Prior to version `2.7.0`**, this could cause linking issues with the Rust compiler.
+
+This can be solved by adding [`openmp-sys`](https://crates.io/crates/openmp-sys) in downstream Rust code.
+However, this shouldn't be necessary with `librna-sys>=0.3` and ViennaRNA `>=2.7.0`.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # librna-sys
 
-This crate provides low-level `Rust` bindings to [`libRNA/RNAlib/ViennaRNA`](https://www.tbi.univie.ac.at/RNA/).
+This crate provides low-level Rust bindings to [`libRNA/RNAlib/ViennaRNA`](https://www.tbi.univie.ac.at/RNA/).
 
 ## Current State
 
-`librna-sys` is **highly experimental** and provides **unsafe low-level bindings**.
-It's possible that building or linking does not work reliably. 
+`librna-sys` is mostly **experimental** and provides **unsafe low-level bindings**.
+You might encounter issues with building or linking this crate but common installation setups of ViennaRNA should work reliably.
 This crate was only tested on Linux but macOS should work as well.
 
 ### Compatibility
@@ -20,24 +20,24 @@ This crate was only tested on Linux but macOS should work as well.
 | `0.2.0` | `2.6.0 - 2.6.2` | Added new header files introduced since 2.4.18 through 2.6.0 |
 | `0.2.1` | `>=2.6.3` | Removed workaround for issue fixed in [#189](https://github.com/ViennaRNA/ViennaRNA/pull/189). |
 | `>=0.2.2` | `>=2.6.4` | Re-added `vrna_config.h` which was removed in `0.2.1` as a workaround for an issue fixed in [#199](https://github.com/ViennaRNA/ViennaRNA/pull/199) |
-| `>=0.3.0` | `>=2.7.0` | Issue [#3](https://github.com/fncnt/librna-sys/issues/3) should be resolved now. Added new header files for `2.7.0` |
+| `>=0.3.0` | `>=2.7.0` | Issue [#3](https://github.com/fncnt/librna-sys/issues/3) should be resolved. Added new header files for `2.7.0` |
 
 This chart might be inconsinstent and incomplete. Please report any inaccuracies.
 In general, only the latest version of ViennaRNA is supported but please reach out if you try to make an older version work.
-Starting with `librna-sys@0.2.0`, I aim to release new minor versions in lockstep with new backwards-incompatible versions of ViennaRNA.
+Starting with `librna-sys@0.2.0`, new minor versions have been released in lockstep with new backwards-incompatible versions of ViennaRNA.
 
 ## Prerequisites
 
-- Install [`Rust`](https://rustup.rs/).
-- Install [`ViennaRNA`](https://www.tbi.univie.ac.at/RNA/#download).
+- Install [Rust](https://rustup.rs/).
+- Install [ViennaRNA](https://www.tbi.univie.ac.at/RNA/#download).
 
-This crate requires the static library (`libRNA.a` on Linux and macOS) as well as the `C` header files.
+This crate requires the static library (`libRNA.a` on Linux and macOS) as well as the C header files.
 
 ## Configuration
 
 ### Using `pkg-config` (preferred method)
 
-If `pkg-config` is available on your system and `ViennaRNA` was installed properly
+If `pkg-config` is available on your system and ViennaRNA was installed properly
 
 ```toml
 [dependencies]
@@ -48,7 +48,7 @@ may be used to automatically set the correct linking options.
 
 ### Using Environment Variables
 
-`librna-sys` exposes two environment variables in case `ViennaRNA` is installed in a custom directory.
+`librna-sys` exposes two environment variables in case ViennaRNA is installed in a custom directory.
 Use them like this:
 
 ```sh
@@ -65,18 +65,18 @@ librna-sys = "0.3"
 
 ## Usage
 
-Please refer to the [original documentation](https://www.tbi.univie.ac.at/RNA/ViennaRNA/doc/html/index.html) of the `C` API.
-In most cases, you probably want to use the official `Python` bindings.
+Please refer to the [original documentation](https://www.tbi.univie.ac.at/RNA/ViennaRNA/doc/html/index.html) of the C API.
+In most cases, you probably want to use the official Python bindings.
 
-Use this crate only if some features of the `C` API are not exposed as `Python` bindings and you prefer writing *unsafe* `Rust` over `C` for some reason.
+Use this crate only if some features of the C API are not exposed as Python bindings and you prefer writing *unsafe* Rust over C for some reason.
 
-### Example: Extending `ViennaRNA`
+### Example: Extending ViennaRNA
 
-[*Note: As of version `2.5.0`, `ViennaRNA` contains support for the base pair distance with pseudoknots.*](https://github.com/ViennaRNA/ViennaRNA/pull/129)
+[*Note: As of version `2.5.0`, ViennaRNA contains support for the base pair distance with pseudoknots.*](https://github.com/ViennaRNA/ViennaRNA/pull/129)
 
-This example is intended to illustrate how `librna-sys` could be used to build upon `ViennaRNA`.
+This example is intended to illustrate how `librna-sys` could be used to build upon ViennaRNA.
 
-[`examples/bpdist.rs`](examples/bpdist.rs) extends the base pair distance of `ViennaRNA` to secondary structures with pseudoknots.
+[`examples/bpdist.rs`](examples/bpdist.rs) extends the base pair distance of ViennaRNA to secondary structures with pseudoknots.
 Building this example by running
 
 ```sh
@@ -95,15 +95,15 @@ print(bp_distance_pk(structures[0], structures[1]))
 ## Contributions
 
 I'm open to any ideas or advice.
-At this point, it's not yet clear where this is going but here are a few thoughts:
 
-- Providing complete *safe* bindings to `ViennaRNA` is probably as complex as a complete rewrite in `Rust`.
-- Perhaps a separate crate could serve as a central collection of *safe* APIs extending `ViennaRNA`.
+It is not necessarily planned to provide *complete, safe* bindings to ViennaRNA.
+However, I would like to restructure this project slightly and add a crate `librna-rs`
+That provides a safely wrapped subset of ViennaRNA functionality that can be extended when the need arises.
 
 ## Known Issues
 
 If you encounter an error including `generated with LTO version X.0 instead of the expected Y.0`,
-you could either recompile `ViennaRNA` yourself or [downgrade your `Rust` toolchain](https://doc.rust-lang.org/rustc/linker-plugin-lto.html#toolchain-compatibility).
+you could either recompile ViennaRNA yourself or [downgrade your `Rust` toolchain](https://doc.rust-lang.org/rustc/linker-plugin-lto.html#toolchain-compatibility).
 Adjusting some [linker-related codegen options](https://doc.rust-lang.org/rustc/codegen-options/index.html#linker) might also help but was not thoroughly tested.
 
 ### Linking OpenMP

--- a/examples/bpdist.rs
+++ b/examples/bpdist.rs
@@ -56,15 +56,15 @@ pub fn bp_distance_pk(s1: &str, s2: &str) -> Option<i32> {
     )
 }
 
-#[pymodule]
-fn libbpdist(_py: Python, m: &PyModule) -> PyResult<()> {
-    #[pyfn(m)]
-    #[pyo3(name = "bp_distance_pk")]
-    fn bp_distance_pk_py(_py: Python, s1: &str, s2: &str) -> PyResult<i32> {
-        Ok(bp_distance_pk(s1, s2).unwrap())
-    }
+#[pyfunction]
+#[pyo3(name = "bp_distance_pk")]
+fn bp_distance_pk_py(s1: &str, s2: &str) -> PyResult<i32> {
+    Ok(bp_distance_pk(s1, s2).unwrap())
+}
 
-    Ok(())
+#[pymodule]
+fn libbpdist(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(bp_distance_pk_py, m)?)
 }
 
 #[cfg(test)]

--- a/src/build.rs
+++ b/src/build.rs
@@ -89,9 +89,6 @@ fn main() {
         .header("src/wrapper.h")
         .parse_callbacks(Box::new(ignored_macros))
         .merge_extern_blocks(true)
-        .clang_args(includes.iter().map(|dir| {
-            "-I".to_string() + dir.to_str().expect("LIBRNA_INCLUDE_DIR is not valid UTF-8")
-        }))
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -88,6 +88,9 @@ fn main() {
         .header("src/wrapper.h")
         .parse_callbacks(Box::new(ignored_macros))
         .merge_extern_blocks(true)
+        .clang_args(includes.iter().map(|dir| {
+            "-I".to_string() + dir.to_str().expect("LIBRNA_INCLUDE_DIR is not valid UTF-8")
+        }))
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -61,10 +61,9 @@ fn main() {
 
             println!("cargo:rustc-link-search=native=/usr/lib");
         }
-        // FIXME: with pkg-config, cargo:rustc-link-search suffices (don't even need it), I don't need explicit cargo:rustc-link-lib
-        // FIXME: actually, that's because pkg-config does it for us
-        // FIXME: make this a loop
+
         const LIBS: &[&str] = &["static=RNA", "stdc++", "gsl", "mpfr", "gomp", "gmp"];
+
         for lib in LIBS {
             println!("cargo:rustc-link-lib={}", lib);
         }

--- a/src/build.rs
+++ b/src/build.rs
@@ -75,7 +75,7 @@ fn main() {
 
     println!("cargo:rustc-link-lib=static=RNA");
     // [ViennaRNA >= 2.5.0] This fixed broken linkage due to dlib when running `cargo test`
-    println!("cargo:rustc-link-lib=static=stdc++");
+    println!("cargo:rustc-link-lib=stdc++");
 
     println!("cargo:rerun-if-changed=src/wrapper.h");
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -124,4 +124,3 @@ fn configure_pkg_config() -> bool {
 fn configure_pkg_config() -> bool {
     false
 }
-

--- a/src/build.rs
+++ b/src/build.rs
@@ -104,7 +104,7 @@ fn main() {
 #[cfg(feature = "auto")]
 fn try_pkg_config() -> Option<Vec<PathBuf>> {
     match pkg_config::Config::new()
-        .atleast_version("2.7.0")
+        .atleast_version("2.5.0")
         .statik(true)
         .probe("RNAlib2")
     {

--- a/src/build.rs
+++ b/src/build.rs
@@ -20,8 +20,10 @@ impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
 }
 
 fn main() {
+    let mut includes: Vec<PathBuf> = vec![];
+
     if !configure_pkg_config() {
-        let include_path = PathBuf::from(env::var("LIBRNA_INCLUDE_DIR").unwrap_or_else(|e| {
+        let mut include_path = PathBuf::from(env::var("LIBRNA_INCLUDE_DIR").unwrap_or_else(|e| {
             println!(
                 "cargo:warning={}. Using default {}={}",
                 e, "LIBRNA_INCLUDE_DIR", "/usr/include"
@@ -31,9 +33,14 @@ fn main() {
         .canonicalize()
         .expect("cannot canonicalize path");
 
-        // metadata for directly depending crates
-        println!("cargo:include={}", &include_path.display());
-        println!("cargo:include={}", include_path.join("ViennaRNA").display());
+        includes.push(include_path.clone());
+        include_path.push("ViennaRNA");
+        includes.push(include_path);
+
+        for include in &includes {
+            // metadata for directly depending crates
+            println!("cargo:include={}", include.display());
+        }
 
         let lib_path = PathBuf::from(env::var("LIBRNA_LIB_DIR").unwrap_or_else(|e| {
             println!(

--- a/src/build.rs
+++ b/src/build.rs
@@ -20,10 +20,8 @@ impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
 }
 
 fn main() {
-    let mut includes: Vec<PathBuf> = vec![];
-
     if !configure_pkg_config() {
-        let mut include_path = PathBuf::from(env::var("LIBRNA_INCLUDE_DIR").unwrap_or_else(|e| {
+        let include_path = PathBuf::from(env::var("LIBRNA_INCLUDE_DIR").unwrap_or_else(|e| {
             println!(
                 "cargo:warning={}. Using default {}={}",
                 e, "LIBRNA_INCLUDE_DIR", "/usr/include"
@@ -33,14 +31,9 @@ fn main() {
         .canonicalize()
         .expect("cannot canonicalize path");
 
-        includes.push(include_path.clone());
-        include_path.push("ViennaRNA");
-        includes.push(include_path);
-
-        for include in &includes {
-            // metadata for directly depending crates
-            println!("cargo:include={}", include.display());
-        }
+        // metadata for directly depending crates
+        println!("cargo:include={}", &include_path.display());
+        println!("cargo:include={}", include_path.join("ViennaRNA").display());
 
         let lib_path = PathBuf::from(env::var("LIBRNA_LIB_DIR").unwrap_or_else(|e| {
             println!(

--- a/src/build.rs
+++ b/src/build.rs
@@ -99,7 +99,7 @@ fn main() {
 #[cfg(feature = "auto")]
 fn configure_pkg_config() -> bool {
     match pkg_config::Config::new()
-        .atleast_version("2.6.0")
+        .atleast_version("2.7.0")
         .probe("RNAlib2")
     {
         Ok(info) => {

--- a/src/build.rs
+++ b/src/build.rs
@@ -83,6 +83,8 @@ fn main() {
     );
 
     println!("cargo:rerun-if-changed=src/wrapper.h");
+    println!("cargo:rerun-if-env-changed=LIBRNA_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=LIBRNA_INCLUDE_DIR");
 
     let bindings = bindgen::Builder::default()
         .header("src/wrapper.h")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,9 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 mod tests {
     use super::{
         vrna_fold_compound, vrna_fold_compound_free, vrna_fold_compound_t, vrna_hamming_distance,
-        vrna_md_t, VRNA_OPTION_EVAL_ONLY,
+        vrna_md_t, VRNA_OPTION_EVAL_ONLY, VRNA_VERSION,
     };
-    use std::ffi::CString;
+    use std::ffi::{CStr, CString};
 
     struct FoldCompound {
         // TODO: this should be wrapped in NonNull<> for proper safe bindings
@@ -65,5 +65,21 @@ mod tests {
     fn test_link_openmp() {
         let sequence = "GUACUGAUGUCGUAUACAGGGCUUUUGACAU";
         let _fc = FoldCompound::new(sequence);
+    }
+
+    #[test]
+    fn test_version_string() {
+        // TODO: Ideally, this would be const but handling Result<>/Option<> types is not const.
+        // TODO: We could use const unsafe str::from_utf8_unchecked() but this still has the null byte.
+        let version_string: Option<&str> = CStr::from_bytes_until_nul(VRNA_VERSION)
+            .ok()
+            .and_then(|v| v.to_str().ok());
+
+        // We're only checking that `version_string` is valid UTF8.
+        // We could check for the specific string:
+        // assert_eq!(version_string, Some("2.7.0"));
+        // but this changes with every patch release of ViennaRNA.
+        assert!(version_string.is_some());
+
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,10 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(improper_ctypes)]
-
+// address some clippy lints originating in the generated bindings
+// TODO: investigate alternatives to simply suppressing these lints
+#![allow(clippy::approx_constant)]
+#![allow(clippy::type_complexity)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(test)]
@@ -19,7 +22,6 @@ mod tests {
     }
 
     impl FoldCompound {
-        #[allow(unused)]
         fn new(sequence: &str) -> Option<FoldCompound> {
             let csequence = CString::new(sequence).expect("CString::new failed");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
 #![allow(non_snake_case)]
 #![allow(improper_ctypes)]
 
-#[cfg(feature = "openmp")]
-extern crate openmp_sys;
-
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(test)]
@@ -56,12 +53,9 @@ mod tests {
         assert_eq!(hamming_distance("ACGUA", "ACGUC"), 1);
     }
 
-    // We only run this test when we're sure that OpenMP is definitely linked!
-    // TODO: If we're sure at some point, that there are "linkable" configurations of ViennaRNA without OpenMP
-    // TODO: we can remove that cfg attribute.
-    // TODO: this test case failing to link would be then a helpful diagnostic.
+    // Prior to ViennaRNA 2.7.0, this would fail linking OpenMP which could be worked around using `openmp-sys`.
+    // This is not necessary anymore, so this test is always run to verify linking works in future releases.
     #[test]
-    #[cfg(feature = "openmp")]
     fn test_link_openmp() {
         let sequence = "GUACUGAUGUCGUAUACAGGGCUUUUGACAU";
         let _fc = FoldCompound::new(sequence);
@@ -80,6 +74,5 @@ mod tests {
         // assert_eq!(version_string, Some("2.7.0"));
         // but this changes with every patch release of ViennaRNA.
         assert!(version_string.is_some());
-
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,25 +3,67 @@
 #![allow(non_snake_case)]
 #![allow(improper_ctypes)]
 
+#[cfg(feature = "openmp")]
+extern crate openmp_sys;
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-// just a simple test as example
 #[cfg(test)]
 mod tests {
-    use super::*;
-
+    use super::{
+        vrna_fold_compound, vrna_fold_compound_free, vrna_fold_compound_t, vrna_hamming_distance,
+        vrna_md_t, VRNA_OPTION_EVAL_ONLY,
+    };
     use std::ffi::CString;
+
+    struct FoldCompound {
+        // TODO: this should be wrapped in NonNull<> for proper safe bindings
+        fc: *mut vrna_fold_compound_t,
+    }
+
+    impl FoldCompound {
+        #[allow(unused)]
+        fn new(sequence: &str) -> Self {
+            let csequence = CString::new(sequence).expect("CString::new failed");
+            // SAFETY: TODO
+            let fc = unsafe {
+                let md = std::ptr::null::<vrna_md_t>();
+                vrna_fold_compound(csequence.as_ptr(), md, VRNA_OPTION_EVAL_ONLY)
+            };
+            Self { fc }
+        }
+    }
+
+    impl Drop for FoldCompound {
+        fn drop(&mut self) {
+            // SAFETY: self.fc is non-null, valid by construction, and has not been freed yet.
+            unsafe {
+                vrna_fold_compound_free(self.fc);
+            }
+        }
+    }
 
     pub fn hamming_distance(s1: &str, s2: &str) -> i32 {
         let seq1 = CString::new(s1).expect("CString::new failed");
         let seq2 = CString::new(s2).expect("CString::new failed");
 
+        // SAFETY: vrna_hamming_distance() is supplied with valid, non-null, immutable Rust-managed references.
         unsafe { vrna_hamming_distance(seq1.as_ptr(), seq2.as_ptr()) }
     }
 
     #[test]
-    fn hamming() {
+    fn test_hamming() {
         assert_eq!(hamming_distance("ACGUA", "ACGUC"), 1);
     }
-}
 
+    // We only run this test when we're sure that OpenMP is definitely linked!
+    // TODO: If we're sure at some point, that there are "linkable" configurations of ViennaRNA without OpenMP
+    // TODO: we can remove that cfg attribute.
+    // TODO: this test case failing to link would be then a helpful diagnostic.
+    #[test]
+    #[cfg(feature = "openmp")]
+    fn test_link_openmp() {
+        let sequence = "GUACUGAUGUCGUAUACAGGGCUUUUGACAU";
+        let _fc = FoldCompound::new(sequence);
+    }
+}

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -152,3 +152,8 @@
 #include <ViennaRNA/datastructures/array.h>
 #include <ViennaRNA/datastructures/string.h>
 #include <ViennaRNA/mconf.h>
+// new since 2.7.0
+#include <ViennaRNA/loops/gquad.h>
+#include <ViennaRNA/constraints/probing.h>
+#include <ViennaRNA/datastructures/sparse_mx.h>
+#include <ViennaRNA/utils/log.h>

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -1,3 +1,4 @@
+#include <ViennaRNA/vrna_config.h>
 #include <ViennaRNA/2Dfold.h>
 #include <ViennaRNA/2Dpfold.h>
 #include <ViennaRNA/alifold.h>
@@ -35,7 +36,9 @@
 #include <ViennaRNA/io/file_formats.h>
 #include <ViennaRNA/io/file_formats_msa.h>
 #include <ViennaRNA/io/utils.h>
-#include <ViennaRNA/json.h>
+#ifdef VRNA_WITH_JSON_SUPPORT
+# include <ViennaRNA/json.h>
+#endif
 #include <ViennaRNA/landscape/findpath.h>
 #include <ViennaRNA/landscape/move.h>
 #include <ViennaRNA/landscape/neighbor.h>
@@ -85,7 +88,10 @@
 #include <ViennaRNA/stringdist.h>
 #include <ViennaRNA/structured_domains.h>
 #include <ViennaRNA/subopt.h>
+#ifdef VRNA_WITH_SVM
 #include <ViennaRNA/svm.h>
+#include <ViennaRNA/utils/svm.h>
+#endif
 #include <ViennaRNA/treedist.h>
 #include <ViennaRNA/unstructured_domains.h>
 #include <ViennaRNA/utils/alignments.h>
@@ -94,9 +100,7 @@
 #include <ViennaRNA/utils/higher_order_functions.h>
 #include <ViennaRNA/utils/strings.h>
 #include <ViennaRNA/utils/structures.h>
-#include <ViennaRNA/utils/svm.h>
 #include <ViennaRNA/utils/units.h>
-#include <ViennaRNA/vrna_config.h>
 #include <ViennaRNA/zscore.h>
 // new since 2.4.18:
 #include <ViennaRNA/pk_plex.h>

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -2,29 +2,20 @@
 #include <ViennaRNA/2Dpfold.h>
 #include <ViennaRNA/alifold.h>
 #include <ViennaRNA/ali_plex.h>
-// DEPRECATED: #include <ViennaRNA/aln_util.h>
 #include <ViennaRNA/alphabet.h>
 #include <ViennaRNA/boltzmann_sampling.h>
 #include <ViennaRNA/centroid.h>
-// DEPRECATED: #include <ViennaRNA/char_stream.h>
 #include <ViennaRNA/cofold.h>
 #include <ViennaRNA/combinatorics.h>
 #include <ViennaRNA/commands.h>
 #include <ViennaRNA/concentrations.h>
 #include <ViennaRNA/constraints/basic.h>
-// DEPRECATED: #include <ViennaRNA/constraints.h>
 #include <ViennaRNA/constraints/hard.h>
-// DEPRECATED: #include <ViennaRNA/constraints_hard.h>
 #include <ViennaRNA/constraints/ligand.h>
-// DEPRECATED: #include <ViennaRNA/constraints_ligand.h>
 #include <ViennaRNA/constraints/SHAPE.h>
-// DEPRECATED: #include <ViennaRNA/constraints_SHAPE.h>
 #include <ViennaRNA/constraints/soft.h>
-// DEPRECATED: #include <ViennaRNA/constraints_soft.h>
-// DEPRECATED: #include <ViennaRNA/convert_epars.h>
 #include <ViennaRNA/datastructures/basic.h>
 #include <ViennaRNA/datastructures/char_stream.h>
-// DEPRECATED: #include <ViennaRNA/data_structures.h>
 #include <ViennaRNA/datastructures/hash_tables.h>
 #include <ViennaRNA/datastructures/heap.h>
 #include <ViennaRNA/datastructures/lists.h>
@@ -33,23 +24,13 @@
 #include <ViennaRNA/dp_matrices.h>
 #include <ViennaRNA/duplex.h>
 #include <ViennaRNA/edit_cost.h>
-// DEPRECATED: #include <ViennaRNA/energy_const.h>
-// DEPRECATED: #include <ViennaRNA/energy_par.h>
 #include <ViennaRNA/equilibrium_probs.h>
 #include <ViennaRNA/eval.h>
-// DEPRECATED: #include <ViennaRNA/exterior_loops.h>
-// DEPRECATED: #include <ViennaRNA/file_formats.h>
-// DEPRECATED: #include <ViennaRNA/file_formats_msa.h>
-// DEPRECATED: #include <ViennaRNA/file_utils.h>
-// DEPRECATED: #include <ViennaRNA/findpath.h>
 #include <ViennaRNA/fold_compound.h>
 #include <ViennaRNA/fold.h>
 #include <ViennaRNA/fold_vars.h>
-// DEPRECATED: #include <ViennaRNA/gquad.h>
 #include <ViennaRNA/grammar.h>
-// DEPRECATED: #include <ViennaRNA/hairpin_loops.h>
 #include <ViennaRNA/heat_capacity.h>
-// DEPRECATED: #include <ViennaRNA/interior_loops.h>
 #include <ViennaRNA/inverse.h>
 #include <ViennaRNA/io/file_formats.h>
 #include <ViennaRNA/io/file_formats_msa.h>
@@ -61,7 +42,6 @@
 #include <ViennaRNA/landscape/paths.h>
 #include <ViennaRNA/landscape/walk.h>
 #include <ViennaRNA/Lfold.h>
-// DEPRECATED: #include <ViennaRNA/loop_energies.h>
 #include <ViennaRNA/loops/all.h>
 #include <ViennaRNA/loops/external.h>
 #include <ViennaRNA/loops/hairpin.h>
@@ -74,26 +54,18 @@
 #include <ViennaRNA/mm.h>
 #include <ViennaRNA/model.h>
 #include <ViennaRNA/move_set.h>
-// DEPRECATED: #include <ViennaRNA/multibranch_loops.h>
-// DEPRECATED: #include <ViennaRNA/naview.h>
-// DEPRECATED: #include <ViennaRNA/neighbor.h>
 #include <ViennaRNA/pair_mat.h>
 #include <ViennaRNA/params/basic.h>
 #include <ViennaRNA/params/constants.h>
 #include <ViennaRNA/params/convert.h>
 #include <ViennaRNA/params/default.h>
-// DEPRECATED: #include <ViennaRNA/params.h>
 #include <ViennaRNA/params/io.h>
 #include <ViennaRNA/part_func_co.h>
 #include <ViennaRNA/part_func.h>
 #include <ViennaRNA/part_func_up.h>
 #include <ViennaRNA/part_func_window.h>
 #include <ViennaRNA/perturbation_fold.h>
-// DEPRECATED: #include <ViennaRNA/PKplex.h>
 #include <ViennaRNA/plex.h>
-// DEPRECATED: #include <ViennaRNA/plot_aln.h>
-// DEPRECATED: #include <ViennaRNA/plot_layouts.h>
-// DEPRECATED: #include <ViennaRNA/plot_structure.h>
 #include <ViennaRNA/plotting/alignments.h>
 #include <ViennaRNA/plotting/layouts.h>
 #include <ViennaRNA/plotting/naview/naview.h>
@@ -102,39 +74,29 @@
 #include <ViennaRNA/plotting/RNApuzzler/RNAturtle.h>
 #include <ViennaRNA/plotting/structures.h>
 #include <ViennaRNA/plotting/utils.h>
-// DEPRECATED: #include <ViennaRNA/plot_utils.h>
 #include <ViennaRNA/ProfileAln.h>
 #include <ViennaRNA/profiledist.h>
-// DEPRECATED: #include <ViennaRNA/PS_dot.h>
-// DEPRECATED: #include <ViennaRNA/read_epars.h>
 #include <ViennaRNA/ribo.h>
 #include <ViennaRNA/RNAstruct.h>
 #include <ViennaRNA/search/BoyerMoore.h>
 #include <ViennaRNA/sequence.h>
 #include <ViennaRNA/snofold.h>
 #include <ViennaRNA/snoop.h>
-// DEPRECATED: #include <ViennaRNA/stream_output.h>
 #include <ViennaRNA/stringdist.h>
-// DEPRECATED: #include <ViennaRNA/string_utils.h>
 #include <ViennaRNA/structured_domains.h>
-// DEPRECATED: #include <ViennaRNA/structure_utils.h>
 #include <ViennaRNA/subopt.h>
 #include <ViennaRNA/svm.h>
-// DEPRECATED: #include <ViennaRNA/svm_utils.h>
 #include <ViennaRNA/treedist.h>
-// DEPRECATED: #include <ViennaRNA/units.h>
 #include <ViennaRNA/unstructured_domains.h>
 #include <ViennaRNA/utils/alignments.h>
 #include <ViennaRNA/utils/basic.h>
 #include <ViennaRNA/utils/cpu.h>
-// DEPRECATED: #include <ViennaRNA/utils.h>
 #include <ViennaRNA/utils/higher_order_functions.h>
 #include <ViennaRNA/utils/strings.h>
 #include <ViennaRNA/utils/structures.h>
 #include <ViennaRNA/utils/svm.h>
 #include <ViennaRNA/utils/units.h>
 #include <ViennaRNA/vrna_config.h>
-// DEPRECATED: #include <ViennaRNA/walk.h>
 #include <ViennaRNA/zscore.h>
 // new since 2.4.18:
 #include <ViennaRNA/pk_plex.h>

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -100,18 +100,33 @@
 #include <ViennaRNA/zscore.h>
 // new since 2.4.18:
 #include <ViennaRNA/pk_plex.h>
-// new since 2.5.0
-#include <ViennaRNA/pf_multifold.h>
-#include <ViennaRNA/subopt_zuker.h>
-#include <ViennaRNA/wrap_dlib.h>
-// new since 2.6.0
-#include <ViennaRNA/params/salt.h>
-#include <ViennaRNA/constraints/soft_special.h>
-#include <ViennaRNA/datastructures/array.h>
-#include <ViennaRNA/datastructures/string.h>
-#include <ViennaRNA/mconf.h>
-// new since 2.7.0
-#include <ViennaRNA/loops/gquad.h>
-#include <ViennaRNA/constraints/probing.h>
-#include <ViennaRNA/datastructures/sparse_mx.h>
-#include <ViennaRNA/utils/log.h>
+#if VRNA_VERSION_MAJOR >= 2 && VRNA_VERSION_MINOR >= 5 && VRNA_VERSION_PATCH >= 0
+# include <ViennaRNA/pf_multifold.h>
+# include <ViennaRNA/subopt_zuker.h>
+# include <ViennaRNA/wrap_dlib.h>
+#endif
+#if VRNA_VERSION_MAJOR >= 2 && VRNA_VERSION_MINOR >= 6 && VRNA_VERSION_PATCH >= 0
+# include <ViennaRNA/params/salt.h>
+# include <ViennaRNA/constraints/soft_special.h>
+# include <ViennaRNA/datastructures/array.h>
+# include <ViennaRNA/datastructures/string.h>
+# include <ViennaRNA/mconf.h>
+#endif
+#if VRNA_VERSION_MAJOR >= 2 && VRNA_VERSION_MINOR >= 7 && VRNA_VERSION_PATCH >= 0
+# include <ViennaRNA/loops/gquad.h>
+# include <ViennaRNA/constraints/probing.h>
+# include <ViennaRNA/datastructures/sparse_mx.h>
+# include <ViennaRNA/utils/log.h>
+#endif
+// `vrna_config.h` provides version macros which allows us to include
+// version-specific header files.
+//
+// Alternatives to this approach would be `-idirafter`
+// cf. https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html
+//
+// or `__has_include`
+// cf. https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html
+//
+// Both of which would require some slightly ugly tricks (adjusting clang_args,
+// splitting `wrapper.h`, providing header stubs, version-specific cargo features, etc.)
+

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -2,29 +2,29 @@
 #include <ViennaRNA/2Dpfold.h>
 #include <ViennaRNA/alifold.h>
 #include <ViennaRNA/ali_plex.h>
-#include <ViennaRNA/aln_util.h>
+// DEPRECATED: #include <ViennaRNA/aln_util.h>
 #include <ViennaRNA/alphabet.h>
 #include <ViennaRNA/boltzmann_sampling.h>
 #include <ViennaRNA/centroid.h>
-#include <ViennaRNA/char_stream.h>
+// DEPRECATED: #include <ViennaRNA/char_stream.h>
 #include <ViennaRNA/cofold.h>
 #include <ViennaRNA/combinatorics.h>
 #include <ViennaRNA/commands.h>
 #include <ViennaRNA/concentrations.h>
 #include <ViennaRNA/constraints/basic.h>
-#include <ViennaRNA/constraints.h>
+// DEPRECATED: #include <ViennaRNA/constraints.h>
 #include <ViennaRNA/constraints/hard.h>
-#include <ViennaRNA/constraints_hard.h>
+// DEPRECATED: #include <ViennaRNA/constraints_hard.h>
 #include <ViennaRNA/constraints/ligand.h>
-#include <ViennaRNA/constraints_ligand.h>
+// DEPRECATED: #include <ViennaRNA/constraints_ligand.h>
 #include <ViennaRNA/constraints/SHAPE.h>
-#include <ViennaRNA/constraints_SHAPE.h>
+// DEPRECATED: #include <ViennaRNA/constraints_SHAPE.h>
 #include <ViennaRNA/constraints/soft.h>
-#include <ViennaRNA/constraints_soft.h>
-#include <ViennaRNA/convert_epars.h>
+// DEPRECATED: #include <ViennaRNA/constraints_soft.h>
+// DEPRECATED: #include <ViennaRNA/convert_epars.h>
 #include <ViennaRNA/datastructures/basic.h>
 #include <ViennaRNA/datastructures/char_stream.h>
-#include <ViennaRNA/data_structures.h>
+// DEPRECATED: #include <ViennaRNA/data_structures.h>
 #include <ViennaRNA/datastructures/hash_tables.h>
 #include <ViennaRNA/datastructures/heap.h>
 #include <ViennaRNA/datastructures/lists.h>
@@ -33,24 +33,23 @@
 #include <ViennaRNA/dp_matrices.h>
 #include <ViennaRNA/duplex.h>
 #include <ViennaRNA/edit_cost.h>
-#include <ViennaRNA/energy_const.h>
-#include <ViennaRNA/energy_par.h>
+// DEPRECATED: #include <ViennaRNA/energy_const.h>
+// DEPRECATED: #include <ViennaRNA/energy_par.h>
 #include <ViennaRNA/equilibrium_probs.h>
 #include <ViennaRNA/eval.h>
-#include <ViennaRNA/exterior_loops.h>
-#include <ViennaRNA/file_formats.h>
-#include <ViennaRNA/file_formats_msa.h>
-#include <ViennaRNA/file_utils.h>
-#include <ViennaRNA/findpath.h>
+// DEPRECATED: #include <ViennaRNA/exterior_loops.h>
+// DEPRECATED: #include <ViennaRNA/file_formats.h>
+// DEPRECATED: #include <ViennaRNA/file_formats_msa.h>
+// DEPRECATED: #include <ViennaRNA/file_utils.h>
+// DEPRECATED: #include <ViennaRNA/findpath.h>
 #include <ViennaRNA/fold_compound.h>
 #include <ViennaRNA/fold.h>
 #include <ViennaRNA/fold_vars.h>
-#include <ViennaRNA/utils/basic.h>
-#include <ViennaRNA/gquad.h>
+// DEPRECATED: #include <ViennaRNA/gquad.h>
 #include <ViennaRNA/grammar.h>
-#include <ViennaRNA/hairpin_loops.h>
+// DEPRECATED: #include <ViennaRNA/hairpin_loops.h>
 #include <ViennaRNA/heat_capacity.h>
-#include <ViennaRNA/interior_loops.h>
+// DEPRECATED: #include <ViennaRNA/interior_loops.h>
 #include <ViennaRNA/inverse.h>
 #include <ViennaRNA/io/file_formats.h>
 #include <ViennaRNA/io/file_formats_msa.h>
@@ -62,7 +61,7 @@
 #include <ViennaRNA/landscape/paths.h>
 #include <ViennaRNA/landscape/walk.h>
 #include <ViennaRNA/Lfold.h>
-#include <ViennaRNA/loop_energies.h>
+// DEPRECATED: #include <ViennaRNA/loop_energies.h>
 #include <ViennaRNA/loops/all.h>
 #include <ViennaRNA/loops/external.h>
 #include <ViennaRNA/loops/hairpin.h>
@@ -75,70 +74,67 @@
 #include <ViennaRNA/mm.h>
 #include <ViennaRNA/model.h>
 #include <ViennaRNA/move_set.h>
-#include <ViennaRNA/multibranch_loops.h>
-#include <ViennaRNA/naview.h>
-#include <ViennaRNA/neighbor.h>
+// DEPRECATED: #include <ViennaRNA/multibranch_loops.h>
+// DEPRECATED: #include <ViennaRNA/naview.h>
+// DEPRECATED: #include <ViennaRNA/neighbor.h>
 #include <ViennaRNA/pair_mat.h>
 #include <ViennaRNA/params/basic.h>
 #include <ViennaRNA/params/constants.h>
 #include <ViennaRNA/params/convert.h>
 #include <ViennaRNA/params/default.h>
-#include <ViennaRNA/params.h>
+// DEPRECATED: #include <ViennaRNA/params.h>
 #include <ViennaRNA/params/io.h>
 #include <ViennaRNA/part_func_co.h>
 #include <ViennaRNA/part_func.h>
 #include <ViennaRNA/part_func_up.h>
 #include <ViennaRNA/part_func_window.h>
 #include <ViennaRNA/perturbation_fold.h>
-#include <ViennaRNA/PKplex.h>
+// DEPRECATED: #include <ViennaRNA/PKplex.h>
 #include <ViennaRNA/plex.h>
-#include <ViennaRNA/plot_aln.h>
-#include <ViennaRNA/plot_layouts.h>
-#include <ViennaRNA/plot_structure.h>
+// DEPRECATED: #include <ViennaRNA/plot_aln.h>
+// DEPRECATED: #include <ViennaRNA/plot_layouts.h>
+// DEPRECATED: #include <ViennaRNA/plot_structure.h>
 #include <ViennaRNA/plotting/alignments.h>
 #include <ViennaRNA/plotting/layouts.h>
-// This was changed to #include <ViennaRNA/plotting/naview/naview.h> in ViennaRNA 2.5.1
-// We'll remove this include for now since #include <ViennaRNA/naview.h> is still available (although deprecated)
-// #include <ViennaRNA/plotting/naview.h>
+#include <ViennaRNA/plotting/naview/naview.h>
 #include <ViennaRNA/plotting/probabilities.h>
 #include <ViennaRNA/plotting/RNApuzzler/RNApuzzler.h>
 #include <ViennaRNA/plotting/RNApuzzler/RNAturtle.h>
 #include <ViennaRNA/plotting/structures.h>
 #include <ViennaRNA/plotting/utils.h>
-#include <ViennaRNA/plot_utils.h>
+// DEPRECATED: #include <ViennaRNA/plot_utils.h>
 #include <ViennaRNA/ProfileAln.h>
 #include <ViennaRNA/profiledist.h>
-#include <ViennaRNA/PS_dot.h>
-#include <ViennaRNA/read_epars.h>
+// DEPRECATED: #include <ViennaRNA/PS_dot.h>
+// DEPRECATED: #include <ViennaRNA/read_epars.h>
 #include <ViennaRNA/ribo.h>
 #include <ViennaRNA/RNAstruct.h>
 #include <ViennaRNA/search/BoyerMoore.h>
 #include <ViennaRNA/sequence.h>
 #include <ViennaRNA/snofold.h>
 #include <ViennaRNA/snoop.h>
-#include <ViennaRNA/stream_output.h>
+// DEPRECATED: #include <ViennaRNA/stream_output.h>
 #include <ViennaRNA/stringdist.h>
-#include <ViennaRNA/string_utils.h>
+// DEPRECATED: #include <ViennaRNA/string_utils.h>
 #include <ViennaRNA/structured_domains.h>
-#include <ViennaRNA/structure_utils.h>
+// DEPRECATED: #include <ViennaRNA/structure_utils.h>
 #include <ViennaRNA/subopt.h>
 #include <ViennaRNA/svm.h>
-#include <ViennaRNA/svm_utils.h>
+// DEPRECATED: #include <ViennaRNA/svm_utils.h>
 #include <ViennaRNA/treedist.h>
-#include <ViennaRNA/units.h>
+// DEPRECATED: #include <ViennaRNA/units.h>
 #include <ViennaRNA/unstructured_domains.h>
 #include <ViennaRNA/utils/alignments.h>
-// Moved this up in front of gquad.h to avoid implicit definition of vrna_alloc()
-// #include <ViennaRNA/utils/basic.h>
+#include <ViennaRNA/utils/basic.h>
 #include <ViennaRNA/utils/cpu.h>
-#include <ViennaRNA/utils.h>
+// DEPRECATED: #include <ViennaRNA/utils.h>
 #include <ViennaRNA/utils/higher_order_functions.h>
 #include <ViennaRNA/utils/strings.h>
 #include <ViennaRNA/utils/structures.h>
 #include <ViennaRNA/utils/svm.h>
 #include <ViennaRNA/utils/units.h>
 #include <ViennaRNA/vrna_config.h>
-#include <ViennaRNA/walk.h>
+// DEPRECATED: #include <ViennaRNA/walk.h>
 #include <ViennaRNA/zscore.h>
 // new since 2.4.18:
 #include <ViennaRNA/pk_plex.h>


### PR DESCRIPTION
This PR prepares a new minor release of `librna-sys`. It will be merged with the next minor release of ViennaRNA.
Notable changes include:

- support for the upcoming release of ViennaRNA `2.7.0`
- removal of deprecated header files
- resolution of #3 (mostly due to ViennaRNA itself, we don't have to decide on any new cargo features to include)
- better handling of custom ViennaRNA installation prefixes
- backwards-compatibility with upstream `>=2.5.0`

